### PR TITLE
Compare to Libsoundfile

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "WavReader",
+            type: .dynamic,
             targets: ["WavReader"]),
     ],
     dependencies: [

--- a/Sources/WavReader/CAPI.swift
+++ b/Sources/WavReader/CAPI.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+var wavReaderIterator: WavReader.Iterator? = nil
+
+@_cdecl("initialize")
+public func initialize(filePath: UnsafePointer<CChar>, blockSize: CInt) {
+    let filename = try! String(cString: filePath)
+    print("initialize with file: ", filename)
+    wavReaderIterator = try! WavReader(
+        filename: filename,
+        blockSize: Int(blockSize)
+    ).makeIterator()
+}
+
+@_cdecl("get_next_block")
+public func getNextBlock(ptr: UnsafeMutablePointer<CFloat>) -> CInt {
+    guard let wavReaderIterator = wavReaderIterator else {
+        return 1
+    }
+
+    guard var block = wavReaderIterator.next() else {
+        return 2
+    }
+
+    ptr.assign(from: &block, count: block.count)
+
+    return 0
+}

--- a/Tests/WavReaderTests/WavFileTests.swift
+++ b/Tests/WavReaderTests/WavFileTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import WavFile
+@testable import WavReader
 
 final class WavFileTests: XCTestCase {
     func testExample() {

--- a/WavReaderMacTests/WavReaderMacTests.swift
+++ b/WavReaderMacTests/WavReaderMacTests.swift
@@ -29,7 +29,7 @@ class WavReaderTests: XCTestCase {
         try! urls.forEach { url in
             print(url)
 
-            let blockSize = 16
+            let blockSize = 1024
             let wavReader = try WavReader(bytes: Data(contentsOf: url, options: .alwaysMapped), blockSize: blockSize)
 
 

--- a/compare_libSoundfile.py
+++ b/compare_libSoundfile.py
@@ -1,0 +1,54 @@
+import os
+import soundfile
+import matplotlib.pyplot as plt
+from ctypes import CDLL, c_int, c_float, c_char_p, POINTER
+
+
+# build and run:
+# swift build -c release && python3 compare_libSoundfile.py
+
+
+LIB_PATH = ".build/x86_64-apple-macosx/release/libWavReader.dylib"
+WAV_FILE = "/Tests/Wavs/24bit-48000.wav"
+BLOCK_SIZE = 1024
+
+
+def main():
+    wav_file_path = os.getcwd() + WAV_FILE
+
+    # get first block of audio from WavReader CAPI
+    wav_reader_lib = get_wav_reader_lib()
+    ptr = c_char_p(wav_file_path.encode())
+    wav_reader_lib.initialize(ptr, BLOCK_SIZE)
+    block_from_wavreader = (c_float * BLOCK_SIZE)()
+    err = wav_reader_lib.get_next_block(block_from_wavreader)
+    print("error: ", err)
+
+    # get first block of audio from soundfile
+    blocks = soundfile.blocks(wav_file_path, BLOCK_SIZE)
+    block_from_soundfile = next(blocks)
+
+    # plot samples
+    plt.plot(block_from_wavreader)
+    plt.plot(block_from_soundfile)
+    plt.show()
+
+    # plot differences
+    diff = [a-b for (a, b) in zip(block_from_soundfile, block_from_wavreader)]
+    plt.plot(diff)
+    plt.show()
+
+
+def get_wav_reader_lib():
+    lib = CDLL(LIB_PATH)
+
+    lib.initialize.argtypes = [c_char_p, c_int]
+    lib.initialize.restype = None
+    lib.get_next_block.argtypes = [POINTER(c_float)]
+    lib.get_next_block.restype = c_int
+
+    return lib
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
There seems to be some kind of sign error. negatives samples are off by +2.0

soundfile vs wav reader:

<img width="752" alt="Bildschirmfoto 2020-04-08 um 20 59 37" src="https://user-images.githubusercontent.com/2410252/78823237-a79be800-79dc-11ea-873c-f8f135cfdd60.png">

difference between wavreader and soundfile samples:

<img width="752" alt="Bildschirmfoto 2020-04-08 um 20 59 40" src="https://user-images.githubusercontent.com/2410252/78823246-ab2f6f00-79dc-11ea-8547-e3c8f6b3aac1.png">

